### PR TITLE
Update RTD link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provide interfaces that convey a standard API for generating visual saliency
 map generation.
 
 ## Documentation
-https://xaitk-saliency.readthedocs.io/en/stable/
+https://xaitk-saliency.readthedocs.io/en/latest/
 
 You can also build the sphinx documentation locally for the most up-to-date
 reference:

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -11,8 +11,11 @@ Interfaces
 
 
 Implementations
+
 * Add new occlusion based classifier scoring in accordance to the v0.1 API draft for ImageClassifierSaliencyMapGenerator.
 
 
 Fixes
 -----
+
+* Update Read the Docs documentation link in README


### PR DESCRIPTION
Fix the RTD link so that documentation points to latest instead of stable.