### PR TITLE
Update generation interface doc-strings for clarity

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -15,6 +15,9 @@ Interfaces
 
 * Add new interfaces in accordance to the v0.1 API draft.
 
+  * Added to doc-strings to expand on detail around saliency heatmap return
+    value range and meaning.
+
 
 Implementations
 

--- a/xaitk_saliency/interfaces/vis_sal_classifier.py
+++ b/xaitk_saliency/interfaces/vis_sal_classifier.py
@@ -42,6 +42,12 @@ class ImageClassifierSaliencyMapGenerator(Plugfigurable):
         equivalent to the perturbation mask output from a
         :meth:`xaitk_saliency.interfaces.perturb_image.PerturbImage.perturb`
         method implementation.
+        These should have the shape `[nMasks x H x W]`, and values in range
+        [0, 1], where a value closer to 1 indicate areas of the image that
+        are *unperturbed*.
+        Note the type of values in masks can be either integer, floating point
+        or boolean within the above range definition.
+        Implementations are responsible for handling these expected variations.
 
         Generated saliency heat-map matrices should be floating-point typed and
         be composed of values in the [0,1] range.
@@ -62,16 +68,12 @@ class ImageClassifierSaliencyMapGenerator(Plugfigurable):
             This should have a shape `[nMasks x nClasses]`, be float-typed and
             with values in the [0,1] range.
         :param perturbed_masks:
-            Perturbation masks over the reference image.
+            Perturbation masks `numpy.ndarray` over the reference image.
             This should be parallel in association to the classification
             results input into the `perturbed_conf` parameter.
             This should have a shape `[nMasks x H x W]`, and values in range
             [0, 1], where a value closer to 1 indicate areas of the image that
             are *unperturbed*.
-
-            Note the type of values in masks can be either integer,
-            floating point or boolean. Implementations are responsible for supporting
-            all three formats of the mask.
 
         :return: Generated visual saliency heat-map for each input class as a
             float-type `numpy.ndarray` of shape `[nClasses x H x W]`.

--- a/xaitk_saliency/interfaces/vis_sal_detection.py
+++ b/xaitk_saliency/interfaces/vis_sal_detection.py
@@ -48,6 +48,23 @@ class ImageDetectionSaliencyMapGenerator (Plugfigurable):
         detections, which is why below we formulate the shape of perturbed
         image detects with `nProps` instead of `nDets`.
 
+        Perturbation mask input into the `perturbed_masks` parameter here is
+        equivalent to the perturbation mask output from a
+        :meth:`xaitk_saliency.interfaces.perturb_image.PerturbImage.perturb`
+        method implementation.
+        These should have the shape `[nMasks x H x W]`, and values in range
+        [0, 1], where a value closer to 1 indicate areas of the image that
+        are *unperturbed*.
+        Note the type of values in masks can be either integer, floating point
+        or boolean within the above range definition.
+        Implementations are responsible for handling these expected variations.
+
+        Generated saliency heat-map matrices should be floating-point typed and
+        be composed of values in the [0,1] range.
+        Values of the saliency heat-maps with values closer to 1.0 represent
+        more salient regions according to the classifier that generated input
+        confidence values.
+
         :param ref_dets:
             Detections, objectness and class scores on a reference image as a
             float-typed array with shape `[nDets x (4+1+nClasses)]`.
@@ -57,8 +74,12 @@ class ImageDetectionSaliencyMapGenerator (Plugfigurable):
             We expect this to be a float-types array with shape
             `[nMasks x nProps x (4+1+nClasses)]`.
         :param perturb_masks:
-            Perturbation masks of the reference image as a float-typed array
-            with shape `[nMasks x H x W]`.
+            Perturbation masks `numpy.ndarray` over the reference image.
+            This should be parallel in association to the detection
+            propositions input into the `perturbed_dets` parameter.
+            This should have a shape `[nMasks x H x W]`, and values in range
+            [0, 1], where a value closer to 1 indicate areas of the image that
+            are *unperturbed*.
         :return:
             A visual saliency heat-map matrix describing each input reference
             detection. These will be float-typed arrays with shape

--- a/xaitk_saliency/interfaces/vis_sal_similarity.py
+++ b/xaitk_saliency/interfaces/vis_sal_similarity.py
@@ -39,6 +39,18 @@ class ImageSimilaritySaliencyMapGenerator (Plugfigurable):
         :meth:`xaitk_saliency.interfaces.perturb_image.PerturbImage.perturb`
         method implementation.
         We expect perturbations to be relative to the second reference image.
+        These should have the shape `[nMasks x H x W]`, and values in range
+        [0, 1], where a value closer to 1 indicate areas of the image that
+        are *unperturbed*.
+        Note the type of values in masks can be either integer, floating point
+        or boolean within the above range definition.
+        Implementations are responsible for handling these expected variations.
+
+        Generated saliency heat-map matrices should be floating-point typed and
+        be composed of values in the [0,1] range.
+        Values of the saliency heat-maps with values closer to 1.0 represent
+        more salient regions according to the classifier that generated input
+        confidence values.
 
         :param ref_descr_1:
             First image reference float feature-vector, shape `[nFeats]`
@@ -48,8 +60,12 @@ class ImageSimilaritySaliencyMapGenerator (Plugfigurable):
             Feature vectors of second reference image perturbations, float
             typed of shape `[nMasks x nFeats]`.
         :param perturbed_masks:
-            Perturbation masks `numpy.ndarray`, float-typed with shape
-            `[nMasks x H x W]` in the [0,1] range.
+            Perturbation masks `numpy.ndarray` over the second reference image.
+            This should bbe parallel in association to the `perturbed_descrs`
+            parameter.
+            This should have a shape `[nMasks x H x W]`, and values in range
+            [0, 1], where a value closer to 1 indicate areas of the image that
+            are *unperturbed*.
         :return: Generated saliency heat-map as a float-typed `numpy.ndarray`
             with shape `[H x W]`.
         """


### PR DESCRIPTION
Update the doc-string descriptions of returns from the 3 `vis_sal_*` interfaces.

This is an incremental precursor to the `[-1, 1]` range update that we talked about.