### PR TITLE
Add an initial properties file for SonarQube scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+### SonarQube
+/.scannerwork/
+
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to xaitk-saliency's documentation!
 
    installation
    releasing
+   miscelaneous
 
 
 Indices and tables

--- a/docs/local_sonarqube_testing.rst
+++ b/docs/local_sonarqube_testing.rst
@@ -1,0 +1,33 @@
+Local SonarQube Testing
+=======================
+Follow the `Try Out SonarQube`_ documentation with the "From the Docker
+image" method.
+As part of the setup of the repository/project you will need to create a token
+for running scans with.
+The below assumes that you have saved this locally somewhere for reference,
+like the example file `~/sonarqube-local-token`.
+
+From the above you will learn that you will need to run the ``sonar-scanner``
+separately from running the local server.
+Documentation and references to acquire the scanner maybe found on their
+`SonarScanner`_ docs page.
+
+Paul has found local success running a script as per the following:
+
+.. code-block:: bash
+
+    #! /bin/bash
+    SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    docker run \
+      --rm \
+      --network host \
+      -e SONAR_HOST_URL="http://localhost:9000" \
+      -e SONAR_LOGIN="$(cat "$HOME"/sonarqube-local-token)" \
+      -v "${SOURCE_DIR}:${SOURCE_DIR}" \
+      -w "${SOURCE_DIR}" \
+      sonarsource/sonar-scanner-cli
+
+
+
+.. _Try Out SonarQube: https://docs.sonarqube.org/latest/setup/get-started-2-minutes/
+.. _SonarScanner: https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/

--- a/docs/miscelaneous.rst
+++ b/docs/miscelaneous.rst
@@ -1,0 +1,8 @@
+Miscelaneous Documentation
+==========================
+
+.. toctree::
+   :maxdepth: 1
+
+   local_sonarqube_testing
+   setting_up_sonarcloud

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -15,6 +15,9 @@ Documentation
   un-commentable RISE perturbation algorithm option. The narrative has
   been more explicitly tuned to follow an "application" narrative.
 
+* Add miscellaneous documentation on how to run a local SonarQube scan and
+  experimental documentation on setting up scanning as a CI workflow job.
+
 Interfaces
 
 * Add new interfaces in accordance to the v0.1 API draft.

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -5,6 +5,10 @@ XAITK-Saliency Pending Release Notes
 Updates / New Features
 ----------------------
 
+CI
+
+* Added properties file for SonarQube scans.
+
 Documentation
 
 * Updated the "Occlusion Saliency" notebook to flow smoother and include

--- a/docs/setting_up_sonarcloud.rst
+++ b/docs/setting_up_sonarcloud.rst
@@ -1,0 +1,157 @@
+Setting Up XAITK-Saliency with SonarCloud
+=========================================
+
+Creating a SonarCloud organization
+----------------------------------
+This will house our repository ("project") dashboard and is parallel to the
+GitHub organization.
+
+* Go to `SonarCloud`_
+
+* Click the "+" button in the upper-right near user drop-down.
+
+* Select "Create a new organization".
+
+* Follow instructions.
+
+  * Part of this will be "Installing" the SonarCloud app at the organization level.
+    Select either "All repositories" or select repositories to enable SonarCloud access to.
+    Currently we have selected access only to the `xaitk-saliency`_ repository.
+
+Create project for `XAITK-Saliency`_
+------------------------------------
+* Go to `SonarCloud`_.
+
+* Click the "+" button in the upper-right near user drop-down.
+
+* Select the "XAITK" organization created above.
+
+* Check our repo in the repos listed.
+
+By default this will enable automatic scanning for common situations including
+PR submissions and master-branch updates.
+This is currently acceptable however this does not report coverage information
+due to the SonarCloud automatic scanning not having access to the unit test
+coverage reports generated during the GitHub Actions-based CI workflow.
+In the future we may want to switch to performing the SonarQube scanning action
+inside our CI workflow, however currently there is the hurdle where PRs from
+forks do not have the appropriate access to submit scan reports without leaning
+private security tokens.
+The following `Setting Analysis method to GitHub Actions`_ is provided as
+purely experimental/historical information.
+
+Setting Analysis method to GitHub Actions
+-----------------------------------------
+**NOTE:** *THIS IS NOT THE CURRENT CONFIGURATION.*
+This documentation here is notionally provided as it was written during
+experimentation and maybe has future value if we attempted again.
+
+This is less setting something up but more deactivating the default setting
+to use SonarCloud Automatic Analysis.
+We chose to do this as SonarCloud automatic analysis has no ability to consider
+unittest code coverage as this is only a byproduct of the CI unittests.
+
+* Go to project page (e.g. https://sonarcloud.io/dashboard?id=XAITK_xaitk-saliency)
+
+* Administration --> Analysis Method
+
+* Toggle off "SonarCloud Automatic Analysis"
+
+We "enabled" the GitHub action method by explicitly configuring a job in our
+GitHub CI workflow to use the `SonarCloud GitHub Action`_ to run the scanner
+and submit the report.
+
+.. code-block:: yaml
+
+    jobs:
+
+      # Add the following step to the end of the `unittests` job.
+      unittests:
+        steps:
+          - name: Upload test coverage artifact
+            uses: actions/upload-artifact@v2
+            with:
+              name: test-coverage-${{ matrix.python-version }}-${{ matrix.opt-extra }}
+              path: coverage.xml
+
+      # For analysis of codebase and submission to sonarcloud.io.
+      sonarcloud:
+        runs-on: ubuntu-latest
+
+        # Requires coverage info generated from a previous unit-test run.
+        needs: unittests
+
+        steps:
+          - uses: actions/checkout@v2
+            with:
+              fetch-depth: 0
+          - name: Pull coverage XML from test run
+            uses: actions/download-artifact@v2
+            with:
+              # Just one version of the coverage. Sonar can't merge a matrix of
+              # coverages yet (2021-06).
+              name: test-coverage-3.7-
+          - name: Munge coverage.xml source path for SonarCloud container use
+            # Bridge the gap between what pytest-cov outputs and SonarCloud repo
+            # source directory assumptions of "/github/workspace/".
+            # We check that the coverage source line is as expected before sed call.
+            run: |
+              grep -E '^\s*<source>.*</source>$' coverage.xml
+              sed -Ei 's|^(\s*)<source>.*</source>|\1<source>/github/workspace/xaitk_saliency</source>|g' coverage.xml
+          - name: SonarCloud Scan
+            uses: sonarsource/sonarcloud-github-action@master
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+
+This *requires* that a ``SONAR_TOKEN`` secret to be defined in the github
+*repository* settings to be accessed within the workflow.
+The application to the *repository* is important because PRs from forks will
+not have access the secret defined in the upstream repository, thus the job
+will fail for those fork-based PRs.
+
+The value for this secret is from a SonarCloud personal security token (see
+below on how to make one of these).
+Currently, Paul Tunison holds the security token that is set to the
+``SONAR_TOKEN`` secret in the upstream `xaitk-saliency`_ repository on GitHub.
+In the future this may be changed by a repo admin, as described in a below
+section.
+
+Creating a personal security token
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Go to `SonarCloud`_.
+
+* Drop down user option in the upper right --> select "My Account"
+
+* Click "Security" tab.
+
+* Enter the descriptive label for the token in the editable box --> Click "Generate"
+
+* Retain one-time-exposed value of token appropriately.
+
+Setting GitHub repository ``SONAR_TOKEN`` secret
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Go to the `XAITK-Saliency`_ repository page.
+
+* Click on "Settings" --> "Secrets"
+
+* If no existing ``SONAR_TOKEN`` secret, click on the "New repository secret"
+  in the upper right.
+
+  * This will open a new page to enter the name of the secret, which should be
+    "SONAR_TOKEN" and a space to paste the value of the secret, which should be
+    the token hash as generated above in `Creating a personal security token`_.
+
+* Otherwise, update the existing secret value by clicking on the "Update"
+  button to the right of the secret entry.
+
+  * This will open a new page to enter a new value for the existing
+    ``SONAR_TOKEN`` secret (i.e. cannot change the name of the secret).
+    There should be a space to paste the value of the secret, which should be
+    the token hash as generated above in `Creating a personal security token`_.
+
+
+.. _SonarCloud: https://sonarcloud.io
+.. _SonarCloud GitHub Action: https://github.com/SonarSource/sonarcloud-github-action
+.. _XAITK-Saliency: https://github.com/XAITK/xaitk-saliency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ addopts = [
     "--tb=long",            # Trace-back print mode.
     "--cov=xaitk_saliency", # Cover our package specifically
     "--cov-report=term",    # Coverage report to terminal
+    "--cov-report=xml:coverage.xml",
 ]
 testpaths = [
     "tests",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+sonar.organization=xaitk
+sonar.projectKey=XAITK_xaitk-saliency
+# this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
+sonar.projectName=xaitk-saliency
+
+# Path to sources
+sonar.sources=xaitk_saliency
+sonar.inclusions=**/*.py
+
+# Path to tests
+sonar.tests=tests
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+# Pre-generated reports for sonar to read test results and coverage
+sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
This is sort of a test to see how the SonarCloud integration works with PRs and if it will even pick up this properties file appropriately.