### PR TITLE
Add support for Windows

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -28,6 +28,8 @@ Documentation
   use-case where the ``GenerateImageClassifierBlackboxSaliency`` interface API
   is not appropriate, i.e. already have masks computed.
 
+* Added support for doc building on Windows by adding a platform check so that "make.bat" is called for and not "make html".
+
 Interfaces
 
 * Update ``PerturbImage`` to only output perturbation masks, dropping physical
@@ -90,6 +92,7 @@ Implementations
 
 * Fix saliency map normalization in both ``OcclusionScoring`` as well as
   ``SimilarityScoring`` to disallow cross-class pollution in the norm.
+
 
 Misc.
 

--- a/docs/sphinx_server.py
+++ b/docs/sphinx_server.py
@@ -11,10 +11,17 @@ and browse to http://localhost:5500
 livereload_: https://pypi.python.org/pypi/livereload
 """
 import os
+import sys
 
 from livereload import Server, shell
 
-rebuild_cmd = shell("make html", cwd=".")
+if sys.platform == "win32":
+    print("Using make.bat")
+    rebuild_cmd = shell("make.bat html", cwd=".")
+else:
+    print("Using Makefile")
+    rebuild_cmd = shell("make html", cwd=".")
+
 rebuild_root = "_build/html"
 
 watch_dirs = [


### PR DESCRIPTION
Working with Paul, added a platform check for Windows so that "make.bat" is called for & not "make html".

