### PR TITLE
Remove use of TestCase base-class

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -13,6 +13,11 @@ Documentation
 
 * Add background material for saliency maps to ``introduction.rst``.
 
+Tests
+
+* Removed use of `unittest.TestCase` as it is not utilized directly in any way
+  that PyTest does not provide.
+
 
 Fixes
 -----

--- a/tests/impls/gen_similarity_sal/test_similarity_scoring.py
+++ b/tests/impls/gen_similarity_sal/test_similarity_scoring.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import numpy as np
 import os
 
@@ -9,7 +7,7 @@ from smqtk_core.configuration import configuration_test_helper
 from tests import DATA_DIR, EXPECTED_MASKS_4x6
 
 
-class TestSimilarityScoring (TestCase):
+class TestSimilarityScoring:
 
     def test_init_(self) -> None:
         """

--- a/tests/impls/perturb_image/test_rise.py
+++ b/tests/impls/perturb_image/test_rise.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import pytest
 import numpy as np
 from smqtk_core.configuration import configuration_test_helper
@@ -7,7 +5,7 @@ from smqtk_core.configuration import configuration_test_helper
 from xaitk_saliency.impls.perturb_image.rise import RISEGrid
 
 
-class TestRISEPerturbation (TestCase):
+class TestRISEPerturbation:
     def test_init_valued(self) -> None:
         """
         Test that constructor values pass.

--- a/tests/impls/perturb_image/test_sliding_window.py
+++ b/tests/impls/perturb_image/test_sliding_window.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import numpy as np
 from smqtk_core.configuration import configuration_test_helper
 
@@ -8,7 +6,7 @@ from xaitk_saliency.impls.perturb_image.sliding_window import SlidingWindow
 from tests import EXPECTED_MASKS_4x6
 
 
-class TestOcclusionBasedPerturb (TestCase):
+class TestOcclusionBasedPerturb:
 
     def test_init_default(self) -> None:
         """


### PR DESCRIPTION
The baseclass was not utilized in any meaningful way that is not already
handled by PyTest.