### PR TITLE
Add expansion in docs and unittests for "fill" with an image

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -30,6 +30,11 @@ Tests
 * Removed use of `unittest.TestCase` as it is not utilized directly in any way
   that PyTest does not provide.
 
+Utilities
+
+* Add type annotation, documentation and unit-tests for using image matrices as
+  the fill option instead of just a solid color.
+
 
 Fixes
 -----

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,8 @@ sonar.organization=xaitk
 sonar.projectKey=XAITK_xaitk-saliency
 # this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
 sonar.projectName=xaitk-saliency
+# this project set to only use python 3.x versions.
+sonar.python.version = 3
 
 # Path to sources
 sonar.sources=xaitk_saliency

--- a/tests/utils/test_masking.py
+++ b/tests/utils/test_masking.py
@@ -107,14 +107,25 @@ class TestOccludeImageCommon:
         ])
         assert np.allclose(res_images, expected_images)
 
-    def test_gray_bool_fill_list_error(self, occ_func: Callable) -> None:
-        """
-        Test using a custom fill color for masked regions as a 3-channel list.
-        """
-        with pytest.raises(ValueError, match=r"operands could not be broadcast together"):
-            # This should error because the input is single channel while the
-            # fill value is 3-channel
-            list(occ_func(TEST_IMAGE_GRAY, TEST_MASKS_BOOL, [255, 0, 255]))
+    def test_rgb_bool_fill_scalar(self, occ_func: Callable) -> None:
+        res_images = list(occ_func(TEST_IMAGE_RGB, TEST_MASKS_BOOL, 44))
+        expected_images = as_uint8([
+            [
+                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
+                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
+                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
+                [[44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255], [44, 44, 44]],
+                [[255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44], [255, 255, 255]],
+            ],
+            [
+                [[44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255], [44, 44, 44]],
+                [[44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255], [44, 44, 44]],
+                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
+                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
+                [[44, 44, 44], [44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255]],
+            ]
+        ])
+        assert np.allclose(res_images, expected_images)
 
     def test_gray_float_fill_scalar(self, occ_func: Callable) -> None:
         # Using 5 because it exposes a detail about float-level accumulation.
@@ -137,31 +148,46 @@ class TestOccludeImageCommon:
         ])
         assert np.allclose(res_images, expected_images)
 
+    def test_rgb_float_fill_scalar(self, occ_func: Callable) -> None:
+        # Using 5 because it exposes a detail about float-level accumulation.
+        res_images = list(occ_func(TEST_IMAGE_RGB, TEST_MASKS_FLOAT, 5))
+        expected_images = as_uint8([
+            [
+                [[255, 255, 255], [192, 192, 192], [130, 130, 130], [67, 67, 67], [5, 5, 5]],
+                [[192, 192, 192], [130, 130, 130], [67, 67, 67], [5, 5, 5], [67, 67, 67]],
+                [[130, 130, 130], [67, 67, 67], [5, 5, 5], [67, 67, 67], [130, 130, 130]],
+                [[67, 67, 67], [5, 5, 5], [67, 67, 67], [130, 130, 130], [192, 192, 192]],
+                [[5, 5, 5], [67, 67, 67], [130, 130, 130], [192, 192, 192], [255, 255, 255]]
+            ],
+            [
+                [[5, 5, 5], [67, 67, 67], [130, 130, 130], [192, 192, 192], [255, 255, 255]],
+                [[67, 67, 67], [130, 130, 130], [192, 192, 192], [255, 255, 255], [192, 192, 192]],
+                [[130, 130, 130], [192, 192, 192], [255, 255, 255], [192, 192, 192], [130, 130, 130]],
+                [[192, 192, 192], [255, 255, 255], [192, 192, 192], [130, 130, 130], [67, 67, 67]],
+                [[255, 255, 255], [192, 192, 192], [130, 130, 130], [67, 67, 67], [5, 5, 5]]
+            ]
+        ])
+        assert np.allclose(res_images, expected_images)
+
+    def test_gray_bool_fill_list_error(self, occ_func: Callable) -> None:
+        """
+        Test using a custom fill color for masked regions as a 3-channel list.
+        For single-channel input this is an error.
+        """
+        with pytest.raises(ValueError, match=r"operands could not be broadcast together"):
+            # This should error because the input is single channel while the
+            # fill value is 3-channel
+            list(occ_func(TEST_IMAGE_GRAY, TEST_MASKS_BOOL, [255, 0, 255]))
+
     def test_gray_float_fill_list_error(self, occ_func: Callable) -> None:
+        """
+        Test using a custom fill color for masked regions as a 3-channel list.
+        For single-channel input this is an error.
+        """
         with pytest.raises(ValueError, match=r"operands could not be broadcast together"):
             # This should error because the input is single channel while the
             # fill value is 3-channel
             list(occ_func(TEST_IMAGE_GRAY, TEST_MASKS_FLOAT, [1, 2, 3]))
-
-    def test_rgb_bool_fill_scalar(self, occ_func: Callable) -> None:
-        res_images = list(occ_func(TEST_IMAGE_RGB, TEST_MASKS_BOOL, 44))
-        expected_images = as_uint8([
-            [
-                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
-                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
-                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
-                [[44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255], [44, 44, 44]],
-                [[255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44], [255, 255, 255]],
-            ],
-            [
-                [[44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255], [44, 44, 44]],
-                [[44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255], [44, 44, 44]],
-                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
-                [[255, 255, 255], [255, 255, 255], [44, 44, 44], [44, 44, 44], [44, 44, 44]],
-                [[44, 44, 44], [44, 44, 44], [44, 44, 44], [255, 255, 255], [255, 255, 255]],
-            ]
-        ])
-        assert np.allclose(res_images, expected_images)
 
     def test_rgb_bool_fill_list(self, occ_func: Callable) -> None:
         # Let's use half-magenta because why not
@@ -180,27 +206,6 @@ class TestOccludeImageCommon:
                 [[255, 255, 255], [255, 255, 255], [128, 0, 128], [128, 0, 128], [128, 0, 128]],
                 [[255, 255, 255], [255, 255, 255], [128, 0, 128], [128, 0, 128], [128, 0, 128]],
                 [[128, 0, 128], [128, 0, 128], [128, 0, 128], [255, 255, 255], [255, 255, 255]],
-            ]
-        ])
-        assert np.allclose(res_images, expected_images)
-
-    def test_rgb_float_fill_scalar(self, occ_func: Callable) -> None:
-        # Using 5 because it exposes a detail about float-level accumulation.
-        res_images = list(occ_func(TEST_IMAGE_RGB, TEST_MASKS_FLOAT, 5))
-        expected_images = as_uint8([
-            [
-                [[255, 255, 255], [192, 192, 192], [130, 130, 130], [67, 67, 67], [5, 5, 5]],
-                [[192, 192, 192], [130, 130, 130], [67, 67, 67], [5, 5, 5], [67, 67, 67]],
-                [[130, 130, 130], [67, 67, 67], [5, 5, 5], [67, 67, 67], [130, 130, 130]],
-                [[67, 67, 67], [5, 5, 5], [67, 67, 67], [130, 130, 130], [192, 192, 192]],
-                [[5, 5, 5], [67, 67, 67], [130, 130, 130], [192, 192, 192], [255, 255, 255]]
-            ],
-            [
-                [[5, 5, 5], [67, 67, 67], [130, 130, 130], [192, 192, 192], [255, 255, 255]],
-                [[67, 67, 67], [130, 130, 130], [192, 192, 192], [255, 255, 255], [192, 192, 192]],
-                [[130, 130, 130], [192, 192, 192], [255, 255, 255], [192, 192, 192], [130, 130, 130]],
-                [[192, 192, 192], [255, 255, 255], [192, 192, 192], [130, 130, 130], [67, 67, 67]],
-                [[255, 255, 255], [192, 192, 192], [130, 130, 130], [67, 67, 67], [5, 5, 5]]
             ]
         ])
         assert np.allclose(res_images, expected_images)
@@ -226,6 +231,152 @@ class TestOccludeImageCommon:
             ]
         ])
         assert np.allclose(res_images, expected_images)
+
+    # fill_image permute with
+    # image: gray, rgb
+    # masks: bool, float
+    def test_gray_bool_fill_img_gray(self, occ_func: Callable) -> None:
+        # combination of TEST_MASKS_BOOL with TEST_FILL_IMG_GRAY
+        expected_images = as_uint8([
+            [[255, 255,  32,  48,  64],
+             [255, 255,  48,  64,  80],
+             [255, 255,  64,  80,  96],
+             [48,   64, 255, 255, 112],
+             [255,  80,  96, 112, 255]],
+            [[0,    16, 255, 255,  64],
+             [16,   32, 255, 255,  80],
+             [255, 255,  64,  80,  96],
+             [255, 255,  80,  96, 112],
+             [64,   80,  96, 255, 255]]
+        ])
+        res_images = list(occ_func(
+            TEST_IMAGE_GRAY,
+            TEST_MASKS_BOOL,
+            fill=TEST_FILL_IMG_GRAY
+        ))
+        assert np.allclose(res_images, expected_images)
+
+    def test_gray_bool_fill_img_rgb_error(self, occ_func: Callable) -> None:
+        """
+        Filling with a multi-channel image when the ref-image is single-channel
+        should be an error.
+        """
+        with pytest.raises(
+            ValueError,
+            match=r"operands could not be broadcast together with shapes "
+                  r"\((2,)?5,5\) \(5,5,3\)"
+        ):
+            list(occ_func(
+                TEST_IMAGE_GRAY,
+                TEST_MASKS_BOOL,
+                fill=TEST_FILL_IMG_RGB
+            ))
+
+    def test_rgb_bool_fill_img_gray_error(self, occ_func: Callable) -> None:
+        """
+        Filling with a single-channel image when the ref-image is multi-channel
+        should be an error.
+        """
+        with pytest.raises(
+            ValueError,
+            match=r"operands could not be broadcast together with shapes "
+                  r"\((2,)?5,5,3\) \((2,)?5,5,5\) \((2,)?5,5,3\)"
+        ):
+            list(occ_func(
+                TEST_IMAGE_RGB,
+                TEST_MASKS_BOOL,
+                fill=TEST_FILL_IMG_GRAY
+            ))
+
+    def test_rgb_bool_fill_img_rgb(self, occ_func: Callable) -> None:
+        res_images = list(occ_func(
+            TEST_IMAGE_RGB,
+            TEST_MASKS_BOOL,
+            fill=TEST_FILL_IMG_RGB,
+        ))
+        expected_images = as_uint8([
+            [[[255, 255, 255], [255, 255, 255], [32, 32, 32], [48, 48, 48], [64, 64, 64]],
+             [[255, 255, 255], [255, 255, 255], [48, 48, 48], [64, 64, 64], [80, 80, 80]],
+             [[255, 255, 255], [255, 255, 255], [64, 64, 64], [80, 80, 80], [96, 96, 96]],
+             [[48, 48, 48], [64, 64, 64], [255, 255, 255], [255, 255, 255], [112, 112, 112]],
+             [[255, 255, 255], [80, 80, 80], [96, 96, 96], [112, 112, 112], [255, 255, 255]]],
+            [[[0, 0, 0], [16, 16, 16], [255, 255, 255], [255, 255, 255], [64, 64, 64]],
+             [[16, 16, 16], [32, 32, 32], [255, 255, 255], [255, 255, 255], [80, 80, 80]],
+             [[255, 255, 255], [255, 255, 255], [64, 64, 64], [80, 80, 80], [96, 96, 96]],
+             [[255, 255, 255], [255, 255, 255], [80, 80, 80], [96, 96, 96], [112, 112, 112]],
+             [[64, 64, 64], [80, 80, 80], [96, 96, 96], [255, 255, 255], [255, 255, 255]]]
+        ])
+        assert np.allclose(res_images, expected_images)
+
+    def test_gray_float_fill_img(self, occ_func: Callable) -> None:
+        res_images = list(occ_func(
+            TEST_IMAGE_GRAY,
+            TEST_MASKS_FLOAT,
+            fill=TEST_FILL_IMG_GRAY
+        ))
+        expected_images = as_uint8([
+            [[255, 195, 143, 99, 64],
+             [195, 143, 99, 64, 123],
+             [143, 99, 64, 123, 175],
+             [99, 64, 123, 175, 219],
+             [64, 123, 175, 219, 255]],
+            [[0, 75, 143, 203, 255],
+             [75, 143, 203, 255, 211],
+             [143, 203, 255, 211, 175],
+             [203, 255, 211, 175, 147],
+             [255, 211, 175, 147, 128]]
+        ])
+        assert np.allclose(res_images, expected_images)
+
+    def test_rgb_float_fill_img(self, occ_func: Callable) -> None:
+        res_images = list(occ_func(
+            TEST_IMAGE_RGB,
+            TEST_MASKS_FLOAT,
+            fill=TEST_FILL_IMG_RGB
+        ))
+        expected_images = as_uint8([
+            [[[255, 255, 255], [195, 195, 195], [143, 143, 143], [99, 99, 99], [64, 64, 64]],
+             [[195, 195, 195], [143, 143, 143], [99, 99, 99], [64, 64, 64], [123, 123, 123]],
+             [[143, 143, 143], [99, 99, 99], [64, 64, 64], [123, 123, 123], [175, 175, 175]],
+             [[99, 99, 99], [64, 64, 64], [123, 123, 123], [175, 175, 175], [219, 219, 219]],
+             [[64, 64, 64], [123, 123, 123], [175, 175, 175], [219, 219, 219], [255, 255, 255]]],
+            [[[0, 0, 0], [75, 75, 75], [143, 143, 143], [203, 203, 203], [255, 255, 255]],
+             [[75, 75, 75], [143, 143, 143], [203, 203, 203], [255, 255, 255], [211, 211, 211]],
+             [[143, 143, 143], [203, 203, 203], [255, 255, 255], [211, 211, 211], [175, 175, 175]],
+             [[203, 203, 203], [255, 255, 255], [211, 211, 211], [175, 175, 175], [147, 147, 147]],
+             [[255, 255, 255], [211, 211, 211], [175, 175, 175], [147, 147, 147], [128, 128, 128]]]
+        ])
+        assert np.allclose(res_images, expected_images)
+
+    def test_fill_img_bad_height_width(self, occ_func: Callable) -> None:
+        """
+        Test that inputting a fill image with inconsistent height, width or
+        both with respect to the ref image is a ValueError.
+        """
+        fill_img = np.full(
+            (3, 4), 255, dtype=np.uint8
+        )
+        with pytest.raises(
+            ValueError,
+            # ()? in the match because in streaming individual images are
+            # broadcast.
+            match=r"operands could not be broadcast together with shapes "
+                  r"\((2,)?5,5\) \(3,4\)"
+        ):
+            list(occ_func(TEST_IMAGE_GRAY, TEST_MASKS_BOOL, fill=fill_img))
+
+    def test_fill_img_bad_channels(self, occ_func: Callable) -> None:
+        fill_img = np.full(
+            (5, 5, 4), 255, dtype=np.uint8
+        )
+        with pytest.raises(
+            ValueError,
+            # ()? in the match because in streaming individual images are
+            # broadcast.
+            match=r"operands could not be broadcast together with shapes "
+                  r"\((2,)?5,5,3\) \((2,)?5,5,4\) \((2,)?5,5,3\)"
+        ):
+            list(occ_func(TEST_IMAGE_RGB, TEST_MASKS_BOOL, fill=fill_img))
 
 
 class TestOccludeImageBatch:
@@ -285,12 +436,14 @@ def test_benchmark() -> None:
     benchmark_occlude_image(threading_tests=[0, 1, 2])
 
 
+# Test input images
 TEST_IMAGE_GRAY = np.full(
     (5, 5), 255, dtype=np.uint8
 )
 TEST_IMAGE_RGB = np.full(
     (5, 5, 3), 255, dtype=np.uint8
 )
+# Test mask inputs
 TEST_MASKS_BOOL = np.asarray([
     [[1, 1, 0, 0, 0],
      [1, 1, 0, 0, 0],
@@ -315,3 +468,12 @@ TEST_MASKS_FLOAT = np.asarray([
      [0.75, 1.00, 0.75, 0.50, 0.25],
      [1.00, 0.75, 0.50, 0.25, 0.00]],
 ], dtype=np.float32)
+# Test "fill" images for alpha-blending
+TEST_FILL_IMG_GRAY = np.array([
+    [0,  16, 32,  48,  64],
+    [16, 32, 48,  64,  80],
+    [32, 48, 64,  80,  96],
+    [48, 64, 80,  96, 112],
+    [64, 80, 96, 112, 128],
+], dtype=np.uint8)
+TEST_FILL_IMG_RGB = np.stack([TEST_FILL_IMG_GRAY]*3).transpose(1, 2, 0)


### PR DESCRIPTION
We discussed that a leading "occlusion" method is to blend with blurred versions of the reference image instead of using a constant color fill. It turns out that our occlusion methods already supported this functionally but not in type annotations, documentation or unit tests, all of which have been updated to describe and test use with images.

I have also offline tested the use of this feature with the "OcclusionSaliency" notebook to see how it works with something not-a-unittest and the results were roughly comparable with the base-line.