### PR TITLE
Fix log message for gen_coco_sal and remove gen_detector_sal release note

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -36,12 +36,6 @@ Implementations
 
 Utilities
 
-* Add ``gen_detector_sal`` function to compute saliency maps for a detection
-  algorithm using any chosen implementations of ``DetectImageObjects``,
-  ``PerturbImage``, and ``GenerateDetectorProposalSaliency``, with accompanying
-  cli script ``det-sal-on-img-dir`` that takes a config file for those
-  implementations.
-
 * Add ``gen_coco_sal`` function to compute saliency maps for detections in a
   ``kwcoco`` dataset, with accompanying cli script ``sal-on-coco-dets`` which
   does this on a COCO formatted json file and writes saliency maps to disk.

--- a/xaitk_saliency/utils/gen_coco_sal.py
+++ b/xaitk_saliency/utils/gen_coco_sal.py
@@ -69,15 +69,15 @@ else:
         else:
             _log = _mute_log
 
-        num_imgs = len(dets_dset.imgs)
+        # filter out images with no detections
+        gid_to_aids = {key: value for (key, value) in dets_dset.gid_to_aids.items() if len(value) > 0}
+
+        num_imgs = len(gid_to_aids)
 
         sal_maps = {}
-        for img_i, (img_id, det_ids) in enumerate(dets_dset.gid_to_aids.items()):
+        for img_i, (img_id, det_ids) in enumerate(gid_to_aids.items()):
 
             num_dets = len(det_ids)
-            # continue if there are no dets for this image
-            if num_dets == 0:
-                continue
 
             img_file = dets_dset.get_image_fpath(img_id)
             ref_img = np.asarray(Image.open(img_file))


### PR DESCRIPTION
The log messages for `gen_coco_sal` prints the current image that saliency is being calculated for out of the total number of images, "(2 / 10)" for example if it was on the 2nd out of 10. The total number of images was previously calculated as the number of images in the kwCoco dataset, leading to an incorrect value if there are images that do not have any detections associated with them. This didn't affect the saliency maps as images with no detections were skipped. I changed the behavior a bit to fix the log message.

Also I noticed that the `gen_detector_sal` module that we removed is still in the release notes, so I removed it.