### PR TITLE
Change download links from Google Drive to data.kitware.com

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -22,5 +22,9 @@ Documentation
   the generic ``PerturbationOcclusion``, and ``DRISEStack`` which uses
   ``RISEGrid`` and ``DRISEScoring`` together.
 
+Examples
+
+* Updated demo resource download links from Google Drive to data.kitware.com
+
 Fixes
 -----

--- a/examples/SerializedDetectionSaliency.ipynb
+++ b/examples/SerializedDetectionSaliency.ipynb
@@ -161,7 +161,7 @@
     "# download weights\n",
     "model_file = os.path.join(data_dir, 'centernet-resnet50.pth')\n",
     "if not os.path.isfile(model_file):\n",
-    "    urllib.request.urlretrieve('https://data.kitware.com/api/v1/file/61e8288d4acac99f426fead2/download', model_file)\n",
+    "    urllib.request.urlretrieve('https://data.kitware.com/api/v1/item/623259f64acac99f426f21db/download', model_file)\n",
     "\n",
     "detector = CenterNetVisdrone(\n",
     "    arch='resnet50',\n",
@@ -193,11 +193,11 @@
     "# Pre-computed detections, COCO-format serialization, top-10 highest confidence detections.\n",
     "dets_path = os.path.join(data_dir, 'coco-dets.json')\n",
     "if not os.path.isfile(dets_path):\n",
-    "    _ = urllib.request.urlretrieve('https://drive.google.com/uc?export=download&id=1-FANSq3MMjuvnNt51xvqvxcSkCTQa-gU', dets_path)\n",
+    "    _ = urllib.request.urlretrieve('https://data.kitware.com/api/v1/item/62325a9d4acac99f426f220b/download', dets_path)\n",
     "\n",
     "img_path = os.path.join(data_dir, 'drone.jpg')\n",
     "if not os.path.isfile(img_path):\n",
-    "    _ = urllib.request.urlretrieve('https://drive.google.com/uc?export=download&id=1Rm4JiJ3yAFntUNEM21uLmh4bomVVogVu', img_path)"
+    "    _ = urllib.request.urlretrieve('https://data.kitware.com/api/v1/item/62325a9e4acac99f426f2213/download', img_path)"
    ]
   },
   {

--- a/examples/VIAME_OcclusionSaliency.ipynb
+++ b/examples/VIAME_OcclusionSaliency.ipynb
@@ -109,7 +109,7 @@
     "os.makedirs(root_dir, exist_ok=True)\n",
     "test_image_filename = os.path.join(root_dir, 'fish.png')\n",
     "if not os.path.isfile(test_image_filename):\n",
-    "    urllib.request.urlretrieve('https://drive.google.com/uc?export=download&id=1SxcsbwaEcZtaj4NJ9PitWkQYsOO5h0w1',\n",
+    "    urllib.request.urlretrieve('https://data.kitware.com/api/v1/item/62325a614acac99f426f21f8/download',\n",
     "                               test_image_filename)\n",
     "\n",
     "plt.figure(figsize=(12, 8))\n",

--- a/examples/atari_deepRL_saliency.ipynb
+++ b/examples/atari_deepRL_saliency.ipynb
@@ -185,7 +185,7 @@
     "os.makedirs(root_dir, exist_ok=True)\n",
     "model_checkpoint = os.path.join(root_dir, 'strong.40.tar')\n",
     "\n",
-    "_ = urllib.request.urlretrieve('https://drive.google.com/uc?export=download&id=1b0NEZop09_EGTSiPalAl_I-a6ZHWz0vG', model_checkpoint)"
+    "_ = urllib.request.urlretrieve('https://data.kitware.com/api/v1/item/62325a1d4acac99f426f21e9/download', model_checkpoint)"
    ]
   },
   {


### PR DESCRIPTION
Swaps out download links for demo resources to data.kitware.com, to be compatible with the JAIC T&E sandbox environment.