### PR TITLE
Revise re-use of smqtk-core publish workflow

### DIFF
--- a/.github/workflows/ci-example-notebooks.yml
+++ b/.github/workflows/ci-example-notebooks.yml
@@ -6,11 +6,12 @@ on:
   push:
     branches:
       - master
-      - release*
+      - release
   pull_request:
     branches:
       - master
-      - release*
+      - release
+      - update-to-v*
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -8,11 +8,12 @@ on:
   push:
     branches:
       - master
-      - release*
+      - release
   pull_request:
     branches:
       - master
-      - release*
+      - release
+      - update-to-v*
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,62 @@
-# Re-use the publishing workflow from smqtk-core
 name: Publish
 
+# Controls when the action will run.
 on:
   push:
     tags:
       # Only run on tags with official version tag release format (e.g. v1.0.1)
       - "v[0-9].[0-9]+.[0-9]+"
 
-jobs:
-  reuse-core-publish:
-    uses: Kitware/SMQTK-Core/.github/workflows/publish.yml@master
+  # Allow use of this workflow as a reusable workflow.
+  # https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+  workflow_call:
     secrets:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      PYPI_TOKEN:
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container: python:3.7
+    # This should only be run for tags on the "official" repository org.
+    if: github.repository_owner == 'XAITK'
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      # Cache local python environment artifacts for the current python version
+      # and poetry lockfile hash.
+      - uses: actions/cache@v2
+        id: env-cache
+        with:
+          # Confirmed that the `.local` directory doesn't exist until the
+          # `pip install --user` is invoked below, so we can be confident that
+          # only our python stuff is being captured in this cache (intentional).
+          path: |
+            ~/.cache/pypoetry/virtualenvs/
+            ~/.local
+          key: python-3.7-${{ hashFiles('poetry.lock') }}
+
+      - name: Setup Environment
+        # Using non-relative path for correct behavior when used as a remote
+        # workflow.
+        uses: Kitware/SMQTK-Core/.github/actions/python-poetry-setup@master
+
+      - name: Publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          if [[ -z "$POETRY_PYPI_TOKEN_PYPI" ]]
+          then
+            echo "ERROR: Input pypi token was blank. Did you forget to set the appropriate secret?"
+            exit 1
+          fi
+          echo "Publishing new tag: ${{ github.ref_name }}"
+          git checkout ${{ github.ref_name }}
+          poetry publish --build

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -11,3 +11,5 @@ CI
 
 * Fix the publish workflow to use appropriate values and version for the
   containing org and this repository.
+
+* Update CI workflows to also run for ``update-to-v*`` branches.

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -6,3 +6,8 @@ Updates / New Features
 
 Fixes
 -----
+
+CI
+
+* Fix the publish workflow to use appropriate values and version for the
+  containing org and this repository.


### PR DESCRIPTION
It was the case that the workflow had a parent-org match check. The
workflow from smqtk-core would check for the "Kitware" org which is not
valid in this case. It was also the case that the shared workflow was
using an incorrect base version of python to build the package in (3.6
vs. 3.7).

This change creates a new version of this workflow with the appropriate
edits that bring into line with the XAITK org and other repository
specifics.