### PR TITLE
Lowered required version after 3.8 hinge

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2600,7 +2600,7 @@ tools = ["kwcoco", "matplotlib"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "976034d4d0a8564e745d6e4eb1595b2f5149efd769a212848700cc366be5b05d"
+content-hash = "c20a34bcf55b9fbbaa9a7a60f6c3bc895dbcd86f5f18bc3c4688f1b61c87aa28"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,22 +33,29 @@ classifiers = [
 [tool.poetry.dependencies]
 # <3.10 being dictated currently by smqtk-detection, which could use some TLC to open up.
 python = ">=3.7,<3.10"
+# Numpy minimum versions for python version learned from:
+# https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table
 numpy = [
-    { version = ">=1.21.1", python = "<3.8" },
-    { version = ">=1.23.5", python = ">=3.8" }
+    { version = ">=1.15", python = "<3.8" },
+    { version = ">1.15", python = ">=3.8" }
 ]
 scikit-image = ">=0.18.1"
+# Scikit-Learn minimum versions for python version learned from:
+# https://scikit-learn.org/stable/install.html#installing-the-latest-release
+# --> See the Warning box at the bottom of the first section.
 scikit-learn = [
-    { version = ">=0.24.2", python = "<3.8" },
-    { version = ">=1.2", python = ">=3.8" }
+    { version = ">=0.21", python = "<3.8" },
+    { version = ">=0.22", python = ">=3.8" }
 ]
 smqtk-classifier = ">=0.17.0"
 smqtk-core = ">=0.18.0"
 smqtk-descriptors = ">=0.16.0"
 smqtk-detection = ">=0.19.0"
+# Scipy minimum versions for python version learned from:
+# https://docs.scipy.org/doc/scipy/dev/toolchain.html#numpy
 scipy = [
     { version = ">=1.6.3", python = "<3.8" },
-    { version = ">=1.8.1", python = ">=3.8" }
+    { version = ">1.6.3", python = ">=3.8" }
 ]
 click = ">=8.0.3"
 # Optionals for "example" extra
@@ -94,9 +101,9 @@ pytest-cov = ">=4.0.0"
 # Utility
 ipython = [
     # As a utility, it is useful to use the latest version in one environment.
-    { version = ">=7.34.0", python = "<3.8" },
+    { version = ">=7", python = "<3.8" },
     # Major version 8 drops support for py3.7
-    { version = ">=8.6.0", python = ">=3.8" }
+    { version = ">=8", python = ">=3.8" }
 ]
 
 [tool.poetry.scripts]
@@ -118,6 +125,7 @@ sal-on-coco-dets= "xaitk_saliency.utils.bin.sal_on_coco_dets:sal_on_coco_dets"
 "impls.gen_object_detector_blackbox_sal.occlusion_based" = "xaitk_saliency.impls.gen_object_detector_blackbox_sal.occlusion_based"
 "impls.gen_image_similarity_blackbox_sal.occlusion_based" = "xaitk_saliency.impls.gen_image_similarity_blackbox_sal.occlusion_based"
 "image.gen_image_similarity_blackbox_sal.sbsm" = "xaitk_saliency.impls.gen_image_similarity_blackbox_sal.sbsm"
+
 ###############################################################################
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
Revision to abstract specifications to be different yet low enough to be open to compatibility with other package requirements.

We need to have a different version specifier for after the hinge, so we only change the ">=" to ">". The versions should follow the minimum required for the python applicable python versions.