### PR TITLE
Fix a few more floating-point comparisons to use epsilon-based method

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -18,6 +18,6 @@ Fixes
 
 Tests
 
-* Update various floating point equality comparisons to not use exact match.
+* Fix various floating point equality comparisons to not use exact match.
 
 * Fix random number usage from numpy to use `np.random.default_rng`.

--- a/tests/impls/gen_classifier_conf_sal/test_rise_scoring.py
+++ b/tests/impls/gen_classifier_conf_sal/test_rise_scoring.py
@@ -31,7 +31,7 @@ class TestRiseScoring:
         """
         inst = RISEScoring(p1=0.747)
         for inst_i in configuration_test_helper(inst):
-            assert inst_i.p1 == 0.747
+            assert np.allclose(inst_i.p1, 0.747)
 
     def test_bad_alignment(self) -> None:
         """

--- a/tests/impls/perturb_image/test_rise.py
+++ b/tests/impls/perturb_image/test_rise.py
@@ -16,7 +16,7 @@ class TestRISEPerturbation:
         impl = RISEGrid(n=ex_n, s=ex_s, p1=ex_p1)
         assert impl.n == ex_n
         assert impl.s == ex_s
-        assert impl.p1 == ex_p1
+        assert np.allclose(impl.p1, ex_p1)
 
     def test_init_outofrange_p1(self) -> None:
         """
@@ -42,7 +42,7 @@ class TestRISEPerturbation:
         for inst in configuration_test_helper(impl):
             assert inst.n == ex_n
             assert inst.s == ex_s
-            assert inst.p1 == ex_p1
+            assert np.allclose(inst.p1, ex_p1)
 
     def test_if_random(self) -> None:
         """


### PR DESCRIPTION
Found on the master analysis report a few more comparisons that were missed in the last batch. This change to clean up the 3 remaining warnings.