### PR TITLE
Fix test_sal_on_coco_dets failure being masked

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -21,3 +21,5 @@ Tests
 * Fix various floating point equality comparisons to not use exact match.
 
 * Fix random number usage from numpy to use `np.random.default_rng`.
+
+* Fix error being masked in `test_sal_on_coco_dets`

--- a/tests/utils/test_sal_on_coco_dets.py
+++ b/tests/utils/test_sal_on_coco_dets.py
@@ -55,19 +55,16 @@ class TestSalOnCocoDets:
         output_dir = tmpdir.join('out')
 
         runner = CliRunner()
-        # TODO: Assign return value to a "result" variable for later
-        runner.invoke(sal_on_coco_dets_cmd,
-                      [str(dets_file), str(output_dir),
-                       str(config_file), "-v"])
+        result = runner.invoke(sal_on_coco_dets_cmd,
+                               [str(dets_file), str(output_dir),
+                                str(config_file), "-v"])
 
         # expected created directories for image saliency maps
         img_dirs = [output_dir.join(d) for d in ["test_image1", "test_image2"]]
         # detection ids that belong to each image
-        img_dets = [[1, 2, 3], [4, 5]]
+        img_dets = [[1, 2, 3], [5, 6]]
 
-        # TODO: This command is failing in reality but not being caught. This
-        #       test needs to be fixed in the future.
-        # assert result.exit_code == 0
+        assert result.exit_code == 0
         assert sorted(output_dir.listdir()) == sorted(img_dirs)
         for img_dir, det_ids in zip(img_dirs, img_dets):
             map_files = [img_dir.join(f"det_{det_id}.jpeg") for det_id in det_ids]
@@ -81,15 +78,16 @@ class TestSalOnCocoDets:
         output_dir = tmpdir.join('out')
 
         runner = CliRunner()
-        runner.invoke(sal_on_coco_dets_cmd,
-                      [str(dets_file), str(output_dir), str(config_file),
-                       "--overlay-image"])
+        result = runner.invoke(sal_on_coco_dets_cmd,
+                               [str(dets_file), str(output_dir), str(config_file),
+                                "--overlay-image"])
 
         # expected created directories for image saliency maps
         img_dirs = [output_dir.join(d) for d in ["test_image1", "test_image2"]]
         # detection ids that belong to each image
-        img_dets = [[1, 2, 3], [4, 5]]
+        img_dets = [[1, 2, 3], [5, 6]]
 
+        assert result.exit_code == 0
         assert sorted(output_dir.listdir()) == sorted(img_dirs)
         for img_dir, det_ids in zip(img_dirs, img_dets):
             map_files = [img_dir.join(f"det_{det_id}.jpeg") for det_id in det_ids]

--- a/xaitk_saliency/utils/bin/sal_on_coco_dets.py
+++ b/xaitk_saliency/utils/bin/sal_on_coco_dets.py
@@ -112,9 +112,11 @@ def sal_on_coco_dets(
     # The outputs of pase_coco_dset() are constructed using gid_to_aids, so we
     # can assume the order of image and annotation ids in gid_to_aids here
     # correspond correctly to that of the generated saliency maps.
+    img_skip_counter = 0
     for img_idx, (img_id, det_ids) in enumerate(dets_dset.gid_to_aids.items()):
         # skip if there are no dets for this image
         if len(det_ids) == 0:
+            img_skip_counter += 1
             continue  # pragma: no cover
 
         img_file = dets_dset.get_image_fpath(img_id)
@@ -131,9 +133,14 @@ def sal_on_coco_dets(
 
         os.makedirs(sub_dir, exist_ok=True)
 
+        sal_skip_counter = 0
         for sal_idx, det_id in enumerate(det_ids):
+            ann = dets_dset.anns[det_id]
+            if not ('score' in ann or 'prob' in ann):
+                sal_skip_counter += 1
+                continue
 
-            sal_map = img_sal_maps[img_idx][sal_idx]
+            sal_map = img_sal_maps[img_idx - img_skip_counter][sal_idx - sal_skip_counter]
 
             fig = plt.figure()
             plt.axis('off')


### PR DESCRIPTION
Tests encapsulated in tests/utils/test_sal_on_coco_dets.py are displaying a "PASS" in pytest's output, but actually raising an exception under the hood and yielding a non-zero return code. The test case was incorrect (including a `det` with no `score` or `pred` value) and did not check the return code. This change fixes the test case and fixes the non-zero return code