### PR TITLE
Add check for no detections

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -8,5 +8,11 @@ Documentation
 
 * Removed a deprecated badge from the README.
 
+Implementations
+
+* Added a check to exit early if no detections were found in `PerturbationOcclusion`
+
+* Added a check to exit early if no saliency maps were generated in `GenerateObjectDetectorBlackboxSaliency`
+
 Fixes
 -----

--- a/tests/interfaces/test_gen_object_detector_blackbox_sal.py
+++ b/tests/interfaces/test_gen_object_detector_blackbox_sal.py
@@ -301,3 +301,38 @@ def test_call_alias() -> None:
         None  # no objectness passed
     )
     assert test_ret == expected_return
+
+
+def test_return_empty_map() -> None:
+    """
+    Test that an empty array of maps is returned properly
+    """
+    m_impl = mock.Mock(spec=GenerateObjectDetectorBlackboxSaliency)
+    m_detector = mock.Mock(spec=DetectImageObjects)
+
+    # test reference detections inputs with matching lengths
+    test_bboxes = np.ones((5, 4), dtype=float)
+    test_scores = np.ones((5, 3), dtype=float)
+
+    # 2-channel image as just HxW should work
+    test_image = np.ones((256, 256), dtype=np.uint8)
+
+    expected_return = np.array([])
+    m_impl._generate.return_value = expected_return
+
+    test_ret = GenerateObjectDetectorBlackboxSaliency.generate(
+        m_impl,
+        test_image,
+        test_bboxes,
+        test_scores,
+        m_detector,
+    )
+
+    m_impl._generate.assert_called_with(
+        test_image,
+        test_bboxes,
+        test_scores,
+        m_detector,
+        None  # no objectness passed
+    )
+    assert len(test_ret) == 0

--- a/xaitk_saliency/impls/gen_object_detector_blackbox_sal/occlusion_based.py
+++ b/xaitk_saliency/impls/gen_object_detector_blackbox_sal/occlusion_based.py
@@ -75,6 +75,9 @@ class PerturbationOcclusion (GenerateObjectDetectorBlackboxSaliency):
 
         pert_dets_mat = _dets_to_formatted_mat(pert_dets)
 
+        if pert_dets_mat.shape[1] == 0:
+            return np.array([])
+
         return self._generator(
             ref_dets_mat,
             pert_dets_mat,

--- a/xaitk_saliency/interfaces/gen_object_detector_blackbox_sal.py
+++ b/xaitk_saliency/interfaces/gen_object_detector_blackbox_sal.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 import abc
 from typing import Optional
@@ -6,6 +8,7 @@ from smqtk_core import Plugfigurable
 from smqtk_detection import DetectImageObjects
 
 from xaitk_saliency.exceptions import ShapeMismatchError
+logger = logging.getLogger(__name__)
 
 
 class GenerateObjectDetectorBlackboxSaliency (Plugfigurable):
@@ -143,6 +146,10 @@ class GenerateObjectDetectorBlackboxSaliency (Plugfigurable):
             blackbox,
             objectness,
         )
+
+        if len(output) == 0:
+            logging.info("No detections found for image. Check DetectImageObjects and saliency configuation")
+            return output
 
         # Check that the saliency heatmaps' shape matches the reference image.
         if output.shape[1:] != ref_image.shape[:2]:


### PR DESCRIPTION
Checks to see if `_dets_to_formatted_mat` returns no detections and returns early. Also added a check to see if any saliency maps were generated in `GenerateObjectDetectorBlackboxSaliency`.